### PR TITLE
Fixed bug cased by the difference in how the checkpoint sequence is stored

### DIFF
--- a/iSBatch.py
+++ b/iSBatch.py
@@ -681,12 +681,12 @@ class LogDataCost(SequenceCost):
         compute_time = 0
         # cost of reservation: alpha * t + beta min(t, reservation) + gamma
         for reservation in self.sequence:
-            cost += cluster_cost.alpha * (reservation[0] - compute_time)
+            cost += cluster_cost.alpha * reservation[0]
             cost += cluster_cost.beta * (
-                min(time, reservation[0]) - compute_time)
+                min(time - compute_time, reservation[0]))
             cost += cluster_cost.gamma
             # stop when the reservation is bigger than the execution time
-            if reservation[0] >= time:
+            if compute_time + reservation[0] >= time:
                 break
             if reservation[1] == 1:
                 compute_time += reservation[0]

--- a/test_unittest.py
+++ b/test_unittest.py
@@ -168,7 +168,7 @@ class TestSequence(unittest.TestCase):
 # test the cost model
 class TestCostModel(unittest.TestCase):
     def test_cost_with_checkpoint(self):
-        sequence = [(4, 1), (10, 0)]
+        sequence = [(4, 1), (6, 0)]
         handler = rqs.LogDataCost(sequence)
         cost = rqs.ClusterCosts(1, 0, 0)
         self.assertEqual(handler.compute_cost([3], cost), 4)


### PR DESCRIPTION
Generated sequences are giving the requested walltime to be used during submission. Example:
```python
sequence = [(4, 1), (6, 0)]
```
ask for 4 time units, checkpoint at the end. If this was not enough ask for additional 6 time units (a total walltime of 10 timeunits).

The function that computes the cost was expecting the sequence to represent the total waltime for an application. The equivalent sequence for the previous example would be: sequence = [(4, 1), (10 0)]

Closes #48 