### PR TITLE
Optimize the number of elements computed during sequence generation 

### DIFF
--- a/iSBatch.py
+++ b/iSBatch.py
@@ -321,8 +321,8 @@ class ResourceEstimator():
         discrete_data, cdf = self.__trim_according_to_limits()
         if len(cdf) < 100:
             warnings.warn("Warning! Sequence is computed based on only %d" \
-                          " elements. Interpolation is recommended" %(
-                              len(cdf)))
+                          " elements. It is recommended to increase the" \
+                          " discretization value." %(len(cdf)))
         handler = sequence_type(discrete_data, cdf, cluster_cost)
         return handler.compute_request_sequence()
 

--- a/iSBatch.py
+++ b/iSBatch.py
@@ -234,8 +234,7 @@ class ResourceEstimator():
             self.__compute_best_fit()
         limits = self.__get_limits()
         self.discrete_data, self.cdf = self.fit_model[
-            self.best_fit_index].get_discrete_cdf(all_data, self.best_fit,
-                                                  limits=limits)
+            self.best_fit_index].get_discrete_cdf(all_data, self.best_fit)
         return self.discrete_data, self.cdf
 
     def __get_sequence_type(self):
@@ -340,14 +339,9 @@ class InterpolationModel():
     def get_empty_fit(self):
         return (-1, -1, np.inf)
 
-    def discretize_data(self, data, discrete_steps, limits=[]):
+    def discretize_data(self, data, discrete_steps):
         upper_limit = max(data)
         lower_limit = min(data)
-        if len(limits) > 0 and limits[0] > min(data):
-            lower_limit = limits[0]
-        if len(limits) > 1:
-            if limits[1] < max(data) and lower_limit < limits[1]:
-                upper_limit = limits[1]
         step = (upper_limit - lower_limit) / discrete_steps
         return np.unique(
             [lower_limit + i * step for i in range(discrete_steps)]
@@ -361,9 +355,8 @@ class FunctionInterpolation(InterpolationModel):
         self.order = order
         self.discrete_steps = discretization - 1
 
-    def get_discrete_cdf(self, data, best_fit, limits=[]):
-        all_data = self.discretize_data(data, self.discrete_steps,
-                                        limits=limits)
+    def get_discrete_cdf(self, data, best_fit):
+        all_data = self.discretize_data(data, self.discrete_steps)
         all_cdf = [max(0, min(1, np.polyval(best_fit, self.fct(d))))
                    for d in all_data]
         # make sure the cdf is always increasing
@@ -391,9 +384,8 @@ class PolyInterpolation(InterpolationModel):
         self.max_order = max_order
         self.discrete_steps = discretization - 1
 
-    def get_discrete_cdf(self, data, best_fit, limits=[]):
-        all_data = self.discretize_data(data, self.discrete_steps,
-                                        limits=limits)
+    def get_discrete_cdf(self, data, best_fit):
+        all_data = self.discretize_data(data, self.discrete_steps)
         all_cdf = [max(0, min(1, np.polyval(best_fit[1], d)))
                    for d in all_data]
         # make sure the cdf is always increasing
@@ -429,12 +421,11 @@ class DistInterpolation(InterpolationModel):
         self.distr = list_of_distr
         self.discrete_steps = discretization - 1
 
-    def get_discrete_cdf(self, data, best_fit, limits=[]):
+    def get_discrete_cdf(self, data, best_fit):
         arg = best_fit[1][:-2]
         loc = best_fit[1][-2]
         scale = best_fit[1][-1]
-        all_data = self.discretize_data(data, self.discrete_steps,
-                                        limits=limits)
+        all_data = self.discretize_data(data, self.discrete_steps)
         all_cdf = [best_fit[0].cdf(d, loc=loc, scale=scale, *arg)
                    for d in all_data]
         return all_data, all_cdf

--- a/iSBatch.py
+++ b/iSBatch.py
@@ -302,6 +302,9 @@ class ResourceEstimator():
             self.fit_model = [interpolation_model]
         else:
             self.fit_model = interpolation_model
+        for model in self.fit_model:
+            if model.discrete_steps < (self.discretization - 1):
+                model.discrete_steps = self.discretization - 1
         self.best_fit = None
         if len(self.fit_model) == 0:
             self.fit_model = None

--- a/iSBatch.py
+++ b/iSBatch.py
@@ -641,7 +641,7 @@ class CheckpointSequence(DefaultRequests):
                 self._beta * self._sumFV, len(self.discret_values) - 1, 0)
 
         for il in range(len(self.discret_values) - 2, -1, -1):
-            for ic in range(len(self.discret_values) - 1, 0, -1):
+            for ic in range(il, 0, -1):
                 if (ic, il) in self._E:
                     continue
                 R = self.CR.get_restart_time(self.discret_values[il])

--- a/test_unittest.py
+++ b/test_unittest.py
@@ -127,6 +127,7 @@ class TestEstimationParameters(unittest.TestCase):
         history = np.loadtxt("examples/logs/truncnorm.in", delimiter=' ')
         params = rqs.ResourceParameters()
         params.interpolation_model = rqs.PolyInterpolation()
+        params.resource_discretization = 2400
         params.request_upper_limit = 12.5
         params.request_lower_limit=12
         wl = rqs.ResourceEstimator(history, params=params)


### PR DESCRIPTION
For the checkpointing sequence (adaptive)
ic (index of the last checkpoint) cannot be greater than il (index of the current reservation)